### PR TITLE
Swift driver off main branch breaking package versions

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -344,7 +344,7 @@ let package = Package(
 
 /// When not using local dependencies, the branch to use for llbuild and TSC repositories.
 //let relatedDependenciesBranch = "main"
-let relatedDependenciesBranch = "swift-DEVELOPMENT-SNAPSHOT-2021-11-02-a"
+let relatedDependenciesBranch = "swift-DEVELOPMENT-SNAPSHOT-2021-10-05-a"
 
 if ProcessInfo.processInfo.environment["SWIFTPM_LLBUILD_FWK"] == nil {
     if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {

--- a/Package.swift
+++ b/Package.swift
@@ -367,7 +367,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         // The 'swift-argument-parser' version declared here must match that
         // used by 'swift-driver' and 'sourcekit-lsp'. Please coordinate
         // dependency version changes here with those projects.
-        .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "0.4.3")),
+        .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "1.0.1")),
         .package(url: "https://github.com/apple/swift-driver.git", .branch(relatedDependenciesBranch)),
         .package(url: "https://github.com/apple/swift-crypto.git", .upToNextMinor(from: "1.1.4")),
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -343,7 +343,8 @@ let package = Package(
 // this right now.
 
 /// When not using local dependencies, the branch to use for llbuild and TSC repositories.
-let relatedDependenciesBranch = "main"
+//let relatedDependenciesBranch = "main"
+let relatedDependenciesBranch = "swift-DEVELOPMENT-SNAPSHOT-2021-11-02-a"
 
 if ProcessInfo.processInfo.environment["SWIFTPM_LLBUILD_FWK"] == nil {
     if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
@@ -366,7 +367,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         // The 'swift-argument-parser' version declared here must match that
         // used by 'swift-driver' and 'sourcekit-lsp'. Please coordinate
         // dependency version changes here with those projects.
-        .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "1.0.1")),
+        .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "0.4.3")),
         .package(url: "https://github.com/apple/swift-driver.git", .branch(relatedDependenciesBranch)),
         .package(url: "https://github.com/apple/swift-crypto.git", .upToNextMinor(from: "1.1.4")),
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -366,7 +366,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         // The 'swift-argument-parser' version declared here must match that
         // used by 'swift-driver' and 'sourcekit-lsp'. Please coordinate
         // dependency version changes here with those projects.
-        .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "1.1.0")),
+        .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "1.2.0")),
         .package(url: "https://github.com/apple/swift-driver.git", .branch(relatedDependenciesBranch)),
         .package(url: "https://github.com/apple/swift-crypto.git", .upToNextMinor(from: "1.1.4")),
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -366,7 +366,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         // The 'swift-argument-parser' version declared here must match that
         // used by 'swift-driver' and 'sourcekit-lsp'. Please coordinate
         // dependency version changes here with those projects.
-        .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "1.2.0")),
+        .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "1.0.1")),
         .package(url: "https://github.com/apple/swift-driver.git", .branch(relatedDependenciesBranch)),
         .package(url: "https://github.com/apple/swift-crypto.git", .upToNextMinor(from: "1.1.4")),
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -366,7 +366,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         // The 'swift-argument-parser' version declared here must match that
         // used by 'swift-driver' and 'sourcekit-lsp'. Please coordinate
         // dependency version changes here with those projects.
-        .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "0.4.3")),
+        .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "1.1.0")),
         .package(url: "https://github.com/apple/swift-driver.git", .branch(relatedDependenciesBranch)),
         .package(url: "https://github.com/apple/swift-crypto.git", .upToNextMinor(from: "1.1.4")),
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -343,8 +343,7 @@ let package = Package(
 // this right now.
 
 /// When not using local dependencies, the branch to use for llbuild and TSC repositories.
-//let relatedDependenciesBranch = "main"
-let relatedDependenciesBranch = "swift-DEVELOPMENT-SNAPSHOT-2021-10-05-a"
+let relatedDependenciesBranch = "main"
 
 if ProcessInfo.processInfo.environment["SWIFTPM_LLBUILD_FWK"] == nil {
     if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {

--- a/Sources/SPMTestSupport/InMemoryGitRepository.swift
+++ b/Sources/SPMTestSupport/InMemoryGitRepository.swift
@@ -201,6 +201,18 @@ public final class InMemoryGitRepository {
     public func fetch() throws {
         // TODO.
     }
+
+    public func isReadable(_ path: AbsolutePath) -> Bool {
+        return true
+    }
+    
+    public func isWritable(_ path: AbsolutePath) -> Bool {
+        return true
+    }
+    
+    public var tempDirectory: AbsolutePath {
+        return AbsolutePath("/tmp")
+    }
 }
 
 extension InMemoryGitRepository: FileSystem {

--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -860,11 +860,17 @@ private class GitFileSystemView: FileSystem {
         fatalError("will never be supported")
     }
 
-    func isReadable(_ path: AbsolutePath) -> Bool
+    func isReadable(_ path: AbsolutePath) -> Bool {
+        return true 
+    }
 
-    func isWritable(_ path: AbsolutePath) -> Bool
+    func isWritable(_ path: AbsolutePath) -> Bool {
+        return true 
+    }
 
-    var tempDirectory: AbsolutePath { get }
+    var tempDirectory: AbsolutePath {
+        return AbsolutePath("/tmp")
+    }
 
 }
 

--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -859,6 +859,13 @@ private class GitFileSystemView: FileSystem {
     func move(from sourcePath: AbsolutePath, to destinationPath: AbsolutePath) throws {
         fatalError("will never be supported")
     }
+
+    func isReadable(_ path: AbsolutePath) -> Bool
+
+    func isWritable(_ path: AbsolutePath) -> Bool
+
+    var tempDirectory: AbsolutePath { get }
+
 }
 
 // MARK: - Errors

--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -861,11 +861,11 @@ private class GitFileSystemView: FileSystem {
     }
 
     func isReadable(_ path: AbsolutePath) -> Bool {
-        return true 
+        return true
     }
 
     func isWritable(_ path: AbsolutePath) -> Bool {
-        return true 
+        return true
     }
 
     var tempDirectory: AbsolutePath {

--- a/Sources/Workspace/Diagnostics.swift
+++ b/Sources/Workspace/Diagnostics.swift
@@ -176,6 +176,8 @@ extension FileSystemError: CustomStringConvertible {
                 return "unknown system error"
             case .alreadyExistsAtDestination:
                 return "already exists in file system"
+            default:
+                return "unsupported operation"
             }
         }
 
@@ -196,6 +198,8 @@ extension FileSystemError: CustomStringConvertible {
             return "unknown system error while operating on \(path)"
         case .alreadyExistsAtDestination:
             return "\(path) already exists in file system"
+        default:
+            return "unsupported operation"
         }
     }
 }


### PR DESCRIPTION
Updates to fix complication.

### Motivation:

Motivation is simply to get it working again.

In Package.swift many of the dependencies are based on the main branch swift-driver. The main branch has been updated a lot, in particular swift-argument-parser was bumped which produces a version compatibility. 

After fixing version compatibility issues, the compiler has several errors mainly from swift protocol implementation issues.  The remainder of the updates are from those issues.

### Modifications:

swift-argument-parser.git has to get bumped to be the same that's used with swift-driver. swift-driver bumped this on Nov 8th. 

The swift complier errored on protocol implementation for case statements and FileSystem classes, so those were updated accordingly. 

### Result:

It compiles.
